### PR TITLE
PVWM v1.3b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Alle Änderungen, Features & Fixes des Moduls werden hier dokumentiert.
 - API-Befehle werden nur gesendet, wenn sich ein Wert tatsächlich ändert  
 - Hysterese für Phasenumschaltung und Start/Stop vollständig implementiert
 - PV-Überschuss < 250 W wird als 0 W angezeigt
-- NoPowerCounter nach 3 aufeinanderfolgenden fehlenden Leistungswerten (unter 100 W) wir angenommen, dass Ladeziel erreicht
+- NoPowerCounter nach 3 aufeinanderfolgenden fehlenden Leistungswerten (unter 100 W) wir Ladeende angenommen
 
 ### Bereinigt
 - Modulstruktur bereinigt und neu organisiert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Alle Änderungen, Features & Fixes des Moduls werden hier dokumentiert.
 - Doppelte Berechnungen und redundante Logs entfernt  
 - API-Befehle werden nur gesendet, wenn sich ein Wert tatsächlich ändert  
 - Hysterese für Phasenumschaltung und Start/Stop vollständig implementiert
+- PV-Überschuss < 250 W wird als 0 W angezeigt
+- NoPowerCounter nach 3 aufeinanderfolgenden fehlenden Leistungswerten (unter 100 W) wir angenommen, dass Ladeziel erreicht
 
 ### Bereinigt
 - Modulstruktur bereinigt und neu organisiert

--- a/PVWallboxManager/module.php
+++ b/PVWallboxManager/module.php
@@ -1289,8 +1289,8 @@ class PVWallboxManager extends IPSModule
                 $this->WriteAttributeInteger('NoPowerCounter', $cnt);
                 $this->LogTemplate('debug', "NoPowerCounter erhöht auf {$cnt}");
 
-                if ($cnt >= 6) {
-                    $this->LogTemplate('ok', "🔌 Ladeende erkannt: keine Leistung nach {$cnt} Updates – beende Ladung.");
+                if ($cnt >= 3) {
+                    $this->LogTemplate('ok', "🔌 Ladeende erkannt: keine Leistung nach {$cnt} Updates (3 Intervalle) – beende Ladung.");
                     $this->SetForceState(1);
                     $this->ResetModiNachLadeende();
                     // Counter zurücksetzen
@@ -1855,8 +1855,11 @@ class PVWallboxManager extends IPSModule
                 $this->ReadPropertyInteger('MinAmpere'),
                 min($this->ReadPropertyInteger('MaxAmpere'), $amp)
             );
-        } elseif ($log) {
-            $this->LogTemplate('debug', "PV-Überschuss <{$cutoff}W ({$rawSurplus}W) → setze auf 0");
+        } else {
+            $rawSurplus = 0;
+            if ($log) {
+                $this->LogTemplate('debug', "PV-Überschuss <{$cutoff}W → nicht angezeigt (auf 0 gesetzt)");
+            }
         }
 
         // Logging & Visualisierung

--- a/PVWallboxManager/module.php
+++ b/PVWallboxManager/module.php
@@ -1240,59 +1240,67 @@ class PVWallboxManager extends IPSModule
 
     private function PruefeLadeendeAutomatisch()
     {
-        // 0) Status aller Modi loggen
+        // 0) Status aller Modi und Force-State loggen
         $currentFRC = $this->GetValue('AccessStateV2'); // 2 = laden erzwungen
-        $manuell    = $this->GetValue('ManuellLaden')  ? 'ja' : 'nein';
-        $pv2car     = $this->GetValue('PV2CarModus')   ? 'ja' : 'nein';
-        $zielzeit   = $this->GetValue('ZielzeitLaden') ? 'ja' : 'nein';
-        $this->LogTemplate('debug', "FRC={$currentFRC}, Manuell={$manuell}, PV2Car={$pv2car}, Zielzeit={$zielzeit}");
-        $this->LogTemplate('debug', 'PruefeLadeendeAutomatisch aufgerufen.');
+        $manuell    = $this->GetValue('ManuellLaden')   ? 'ja' : 'nein';
+        $pv2car     = $this->GetValue('PV2CarModus')    ? 'ja' : 'nein';
+        $zielzeit   = $this->GetValue('ZielzeitLaden')  ? 'ja' : 'nein';
+        $this->LogTemplate('debug', "PruefeLadeendeAutomatisch aufgerufen: FRC={$currentFRC}, Manuell={$manuell}, PV2Car={$pv2car}, Zielzeit={$zielzeit}");
 
-        // 1) SOC-Properties auslesen
+        // 1) SOC-Werte einlesen
         $socID       = $this->ReadPropertyInteger('CarSOCID');
         $socTargetID = $this->ReadPropertyInteger('CarTargetSOCID');
-        $this->LogTemplate('debug', "CarSOCID={$socID}, CarTargetSOCID={$socTargetID}");
-        $socAktuell = ($socID > 0 && IPS_VariableExists($socID)) ? GetValue($socID) : null;
-        $socZiel    = ($socTargetID > 0 && IPS_VariableExists($socTargetID)) ? GetValue($socTargetID) : null;
-        $this->LogTemplate('debug', sprintf("SOC-Aktuell=%s, SOC-Ziel=%s",
-            var_export($socAktuell, true), var_export($socZiel, true)));
+        $socAktuell  = ($socID > 0 && IPS_VariableExists($socID))              ? GetValue($socID)        : null;
+        $socZiel     = ($socTargetID > 0 && IPS_VariableExists($socTargetID)) ? GetValue($socTargetID) : null;
+        $this->LogTemplate('debug', "SOC-Aktuell={$socAktuell}, SOC-Ziel={$socZiel}");
 
-        // 2) Freigabe prüfen
-        $aktFreigabe = ($currentFRC == 2);
-        $this->LogTemplate('debug', 'Ladefreigabe aktiv: ' . ($aktFreigabe ? 'ja' : 'nein'));
+        // 2) Prüfen, ob gerade geladen wird (erzwungen ODER einer der Modi aktiv)
+        $loadActive = (
+            $currentFRC === 2
+            || $this->GetValue('ManuellLaden')
+            || $this->GetValue('PV2CarModus')
+            || $this->GetValue('ZielzeitLaden')
+        );
+        $this->LogTemplate('debug', 'Ladefreigabe/Modus aktiv: ' . ($loadActive ? 'ja' : 'nein'));
 
-        // 3) Primäre Erkennung über SOC-Schwelle
-        if ($aktFreigabe && $socAktuell !== null && $socZiel !== null) {
+        // 3) Primäre Erkennung per SOC
+        if ($loadActive && $socAktuell !== null && $socZiel !== null) {
             if ($socAktuell >= $socZiel) {
                 $this->LogTemplate('ok', "🔌 Ziel-SOC erreicht ({$socAktuell}% ≥ {$socZiel}%) – beende Ladung.");
                 $this->SetForceState(1);
                 $this->ResetModiNachLadeende();
-            } else {
-                $this->LogTemplate('debug', "SOC noch nicht erreicht (Aktuell: {$socAktuell}%, Ziel: {$socZiel}%).");
+                // Counter zurücksetzen
+                $this->WriteAttributeInteger('NoPowerCounter', 0);
+                return;
             }
-            return;
+            // SOC noch nicht erreicht → weiter zum Fallback
+            $this->LogTemplate('debug', "SOC ({$socAktuell}%) < Ziel ({$socZiel}%) – Fallback wird geprüft.");
         }
 
-        // 4) Fallback: NoPowerCounter in allen Lademodi, solange Ladefreigabe aktiv
-        if ($aktFreigabe || $this->GetValue('ManuellLaden') || $this->GetValue('PV2CarModus') || $this->GetValue('ZielzeitLaden')) {
-            $ladeleistung = $this->GetValue('Leistung');
-            $cntVorher    = $this->ReadAttributeInteger('NoPowerCounter');
-            $this->LogTemplate('debug', "Fallback-Pfad: Ladeleistung={$ladeleistung} W, NoPowerCounter vorher={$cntVorher}");
+        // 4) Fallback: No-Power-Counter
+        if ($loadActive) {
+            $leistung  = $this->GetValue('Leistung');
+            $cntVorher = $this->ReadAttributeInteger('NoPowerCounter');
+            $this->LogTemplate('debug', "Fallback-Pfad: Leistung={$leistung} W, NoPowerCounter vorher={$cntVorher}");
 
-            if ($ladeleistung < 100) {
+            if ($leistung < 100) {
+                // kein Strom → Counter hochzählen
                 $cnt = $cntVorher + 1;
                 $this->WriteAttributeInteger('NoPowerCounter', $cnt);
                 $this->LogTemplate('debug', "NoPowerCounter erhöht auf {$cnt}");
+
                 if ($cnt >= 6) {
-                    $this->LogTemplate('ok', "🔌 Ladeende erkannt: keine Leistung nach {$cnt} Updates – Ladevorgang beendet.");
+                    $this->LogTemplate('ok', "🔌 Ladeende erkannt: keine Leistung nach {$cnt} Updates – beende Ladung.");
                     $this->SetForceState(1);
                     $this->ResetModiNachLadeende();
+                    // Counter zurücksetzen
                     $this->WriteAttributeInteger('NoPowerCounter', 0);
                     $this->LogTemplate('debug', "NoPowerCounter zurückgesetzt");
                 }
             } else {
+                // Leistung wieder da → Counter sofort zurücksetzen
                 $this->WriteAttributeInteger('NoPowerCounter', 0);
-                $this->LogTemplate('debug', 'Leistung ≥100 W → NoPowerCounter zurückgesetzt');
+                $this->LogTemplate('debug', 'Leistung ≥100 W → NoPowerCounter zurückgesetzt');
             }
         } else {
             $this->LogTemplate('debug', 'Kein aktiver Lademodus oder keine Freigabe – Fallback übersprungen.');


### PR DESCRIPTION
## [1.3b] - 2025-07-29
### Hinzugefügt
- SOC-Werte (IST/ZIEL) werden jetzt in allen Lademodi berücksichtigt  
- Manuelles Vollladen startet sofort mit konfigurierter Stromstärke und Phasen (Hysterese nicht angewendet)

### Geändert
- Status-Anzeige komplett neu gestaltet  
- „Warte auf Fahrzeug“ umbenannt in „Fahrzeug verbunden / Bereit zum Laden“  
- Modul-deaktiviert-Zustand wird jetzt angezeigt  
- SOC IST/ZIEL vom Fahrzeug in der Status-Info angezeigt

### Behoben
- Anzeige- und Berechnungsfehler in der Status-Info korrigiert  
- Doppelte Berechnungen und redundante Logs entfernt  
- API-Befehle werden nur gesendet, wenn sich ein Wert tatsächlich ändert  
- Hysterese für Phasenumschaltung und Start/Stop vollständig implementiert
- PV-Überschuss < 250 W wird als 0 W angezeigt
- NoPowerCounter nach 3 aufeinanderfolgenden fehlenden Leistungswerten (unter 100 W) wir Ladeende angenommen

### Bereinigt
- Modulstruktur bereinigt und neu organisiert