### PR TITLE
update v1.3b

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -21,7 +21,7 @@ Hier werden geplante Features gesammelt, Community-Wünsche, Ideen und größere
 - [ ] **Weitere Lademodi und Features**
     - [ ] Zeitgesteuertes Laden (z.B. Zielzeit, günstige Börsenzeiten)
     - [x] PV2Car mit Prozentsteuerung -> **Umgesetzt in: v1.1b**
-    - [ ] neuer Lademodi (Laden Manuell steuern) -> Start/Stop, Amperevorgabe, Phasenvorgabe
+    - [x] neuer Lademodi (Laden Manuell steuern) -> Start/Stop, Amperevorgabe, Phasenvorgabe
 
 ---
 

--- a/PVWallboxManager/module.json
+++ b/PVWallboxManager/module.json
@@ -3,7 +3,7 @@
   "name": "PVWallboxManager",
   "type": 3,
   "vendor": "Sol-IoTiv (Austria])",
-  "version": "1.2b",
+  "version": "1.3b",
   "aliases": [
     "PVWallboxManager"
   ],

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "compatibility": {
         "version": "7.1"
     },
-    "version": "1.2b",
+    "version": "1.3b",
     "build": 0,
     "date": 0
 }


### PR DESCRIPTION
## [1.3b] - 2025-07-29
### Hinzugefügt
- SOC-Werte (IST/ZIEL) werden jetzt in allen Lademodi berücksichtigt  
- Manuelles Vollladen startet sofort mit konfigurierter Stromstärke und Phasen (Hysterese nicht angewendet)

### Geändert
- Status-Anzeige komplett neu gestaltet  
- „Warte auf Fahrzeug“ umbenannt in „Fahrzeug verbunden / Bereit zum Laden“  
- Modul-deaktiviert-Zustand wird jetzt angezeigt  
- SOC IST/ZIEL vom Fahrzeug in der Status-Info angezeigt

### Behoben
- Anzeige- und Berechnungsfehler in der Status-Info korrigiert  
- Doppelte Berechnungen und redundante Logs entfernt  
- API-Befehle werden nur gesendet, wenn sich ein Wert tatsächlich ändert  
- Hysterese für Phasenumschaltung und Start/Stop vollständig implementiert
- PV-Überschuss < 250 W wird als 0 W angezeigt
- NoPowerCounter nach 3 aufeinanderfolgenden fehlenden Leistungswerten (unter 100 W) wir Ladeende angenommen

### Bereinigt
- Modulstruktur bereinigt und neu organisiert